### PR TITLE
Fix builds w/ baseurl

### DIFF
--- a/buildspec_pr.yml
+++ b/buildspec_pr.yml
@@ -11,7 +11,7 @@ phases:
       - bundle install
   build:
     commands:
-      - bundle exec jekyll build --baseurl=${CODEBUILD_SOURCE_VERSION}
+      - bundle exec jekyll build --baseurl=/${CODEBUILD_SOURCE_VERSION}
       - export BUCKET_NAME=<preview bucket name>
       - export SITE_PATH=$BUCKET_NAME/${CODEBUILD_SOURCE_VERSION}
       - aws s3 sync _site s3://$SITE_PATH

--- a/jekyll/_posts/2018-10-16-simple-static-blog-terraform.md
+++ b/jekyll/_posts/2018-10-16-simple-static-blog-terraform.md
@@ -410,7 +410,7 @@ phases:
   build:
     commands:
       # Prepend the PR number to the urls in the jekyll build...
-      - bundle exec jekyll build --baseurl=${CODEBUILD_SOURCE_VERSION}
+      - bundle exec jekyll build --baseurl=/${CODEBUILD_SOURCE_VERSION}
       - export BUCKET_NAME=<YOUR BUCKET NAME HERE>
       # ...and the sync destination
       - export SITE_PATH=$BUCKET_NAME/${CODEBUILD_SOURCE_VERSION}


### PR DESCRIPTION
Not using a `/` in the beginning of baseurl leads to some odd behaviors, like doubling the baseurl for post links